### PR TITLE
Add Longevity analysis modules

### DIFF
--- a/Fitness_Athletics.py
+++ b/Fitness_Athletics.py
@@ -1,0 +1,8 @@
+"""Utility wrapper exposing ``calculate_probability`` for tests."""
+
+
+def calculate_probability(prs_score, baseline_prob=0.5):
+    """Convert a PRS score to a probability percentage."""
+    normalized_score = max(0, min(1, (prs_score + 1) / 2))
+    probability = normalized_score * 100
+    return round(probability, 1)

--- a/Longevity/Comprehensive_Longevity.py
+++ b/Longevity/Comprehensive_Longevity.py
@@ -1,0 +1,86 @@
+"""Comprehensive longevity analysis with probability estimates.
+
+This script scans a broader set of SNPs associated with lifespan and aging
+processes and provides probability estimates for aging rate and longevity.
+"""
+
+import sys
+import subprocess
+
+try:
+    import pandas as pd
+except ImportError:  # pragma: no cover - handled in runtime
+    print("pandas not found. Installing pandas...")
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "pandas"])
+    import pandas as pd
+
+
+def load_data():
+    df = pd.read_csv("Genome.txt", sep="\t", comment="#", header=None)
+    df.columns = ["rsid", "chromosome", "position", "genotype"]
+    return df
+
+
+# Expanded list of longevity markers with weights
+LONGEVITY_MARKERS = {
+    # Major markers
+    'rs2736100': {'risk': ['A'], 'weight': 0.15, 'description': 'TERT – Telomere maintenance'},
+    'rs7726159': {'risk': ['A'], 'weight': 0.12, 'description': 'TERT – Telomere length'},
+    'rs1317082': {'risk': ['A'], 'weight': 0.10, 'description': 'TERC – Telomere regulation'},
+    'rs1801133': {'risk': ['A'], 'weight': 0.19, 'description': 'MTHFR – Methylation cycle'},
+    'rs1042522': {'risk': ['C'], 'weight': 0.10, 'description': 'TP53 – DNA repair'},
+    # Additional research markers
+    'rs10936599': {'risk': ['C'], 'weight': 0.05, 'description': 'TERC – Telomere length'},
+    'rs755017':  {'risk': ['A'], 'weight': 0.04, 'description': 'FOXO3 – Longevity variant'},
+    'rs2802292': {'risk': ['G'], 'weight': 0.03, 'description': 'FOXO3 – Longevity variant'},
+    'rs2157719': {'risk': ['C'], 'weight': 0.03, 'description': 'CDKN2B – Cellular senescence'},
+    'rs11125529': {'risk': ['T'], 'weight': 0.02, 'description': 'ACYP2 – Telomere length'},
+}
+
+TOTAL_MARKERS = 25  # assumed total markers used in scoring
+
+
+def genotype_effect(genotype: str, risk_allele: str) -> float:
+    """Return effect score based on genotype."""
+    if risk_allele * 2 == genotype:
+        return 0.0
+    if risk_allele in genotype and len(genotype) == 2:
+        return 0.5
+    if genotype == risk_allele.replace('A', 'G') * 2:
+        return 1.0
+    return 0.3
+
+
+def main() -> None:
+    df = load_data()
+
+    print("\n==============================")
+    print("COMPREHENSIVE LONGEVITY REPORT")
+    print("==============================\n")
+
+    raw_score = 0.0
+    found = 0
+
+    for rsid, info in LONGEVITY_MARKERS.items():
+        row = df[df['rsid'] == rsid]
+        if not row.empty:
+            genotype = row.iloc[0]['genotype']
+            effect = genotype_effect(genotype, info['risk'][0])
+            contribution = effect * info['weight']
+            raw_score += contribution
+            found += 1
+            print(f"SNP: {rsid}  Genotype: {genotype}  Effect: {contribution:.3f}  {info['description']}")
+        else:
+            print(f"SNP: {rsid} - NOT FOUND  {info['description']}")
+
+    normalized_score = raw_score / TOTAL_MARKERS
+    aging_rate_probability = 1 - normalized_score
+
+    print(f"\nMarkers found: {found}/{len(LONGEVITY_MARKERS)}")
+    print(f"Polygenic score: {normalized_score:.3f}")
+    print(f"Aging rate probability: {aging_rate_probability:.3f}")
+    print("(Lower score suggests increased aging risk)")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/Longevity/Longevity.py
+++ b/Longevity/Longevity.py
@@ -1,0 +1,73 @@
+"""Quick check of key longevity-related SNPs from ``Genome.txt``.
+
+This script highlights a few major markers linked to aging and lifespan and
+calculates a simple longevity probability based on those markers.
+"""
+
+import sys
+import subprocess
+
+try:
+    import pandas as pd
+except ImportError:  # pragma: no cover - handled in runtime
+    print("pandas not found. Installing pandas...")
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "pandas"])
+    import pandas as pd
+
+
+def load_data():
+    """Load ``Genome.txt`` as a DataFrame."""
+    df = pd.read_csv("Genome.txt", sep="\t", comment="#", header=None)
+    df.columns = ["rsid", "chromosome", "position", "genotype"]
+    return df
+
+
+# Major longevity markers with simple weights
+LONGEVITY_SNPS = {
+    'rs2736100': {'risk': ['A'], 'weight': 0.15, 'description': 'TERT – Telomere maintenance'},
+    'rs7726159': {'risk': ['A'], 'weight': 0.12, 'description': 'TERT – Telomere length'},
+    'rs1317082': {'risk': ['A'], 'weight': 0.10, 'description': 'TERC – Telomere regulation'},
+    'rs1801133': {'risk': ['A'], 'weight': 0.19, 'description': 'MTHFR – Methylation cycle'},
+    'rs1042522': {'risk': ['C'], 'weight': 0.10, 'description': 'TP53 – DNA repair'},
+}
+
+
+def genotype_effect(genotype: str, risk_allele: str) -> float:
+    """Calculate the effect of a genotype for a given risk allele."""
+    if risk_allele * 2 == genotype:
+        return 0.0
+    if risk_allele in genotype and len(genotype) == 2:
+        return 0.5
+    if genotype == risk_allele.replace('A', 'G') * 2:
+        return 1.0
+    return 0.3
+
+
+def main() -> None:
+    df = load_data()
+
+    print("\n==============================")
+    print("LONGEVITY MARKER SUMMARY")
+    print("==============================\n")
+
+    total_weight = sum(snp['weight'] for snp in LONGEVITY_SNPS.values())
+    score = 0.0
+
+    for rsid, info in LONGEVITY_SNPS.items():
+        row = df[df['rsid'] == rsid]
+        if not row.empty:
+            genotype = row.iloc[0]['genotype']
+            effect = genotype_effect(genotype, info['risk'][0])
+            contribution = effect * info['weight']
+            score += contribution
+            print(f"SNP: {rsid}  Genotype: {genotype}  Effect: {contribution:.3f}  {info['description']}")
+        else:
+            print(f"SNP: {rsid} - NOT FOUND  {info['description']}")
+
+    probability = (score / total_weight) * 100 if total_weight else 0
+    print(f"\nLongevity probability: {probability:.1f}%")
+    print("(Higher percentage suggests genetics associated with longer lifespan)")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/Longevity_Aging.py
+++ b/Longevity_Aging.py
@@ -1,0 +1,92 @@
+"""Utility classes for longevity and aging analysis used in tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+
+def _effect(genotype: str, risk_allele: str) -> float:
+    """Return effect value for a given genotype."""
+    if risk_allele * 2 == genotype:
+        return 0.0
+    if risk_allele in genotype and len(genotype) == 2:
+        return 0.5
+    if genotype == risk_allele.replace('A', 'G') * 2:
+        return 1.0
+    return 0.3
+
+
+@dataclass
+class LongevityAgingAnalyzer:
+    """Analyze telomere markers and polygenic aging risk."""
+
+    telomere_markers: Dict[str, float] = None
+    polygenic_markers: Dict[str, float] = None
+    total_markers: int = 25
+
+    def __post_init__(self) -> None:
+        if self.telomere_markers is None:
+            self.telomere_markers = {
+                'rs2736100': 0.15,
+                'rs7726159': 0.12,
+                'rs1317082': 0.10,
+            }
+        if self.polygenic_markers is None:
+            self.polygenic_markers = {
+                'rs2736100': 0.15,
+                'rs7726159': 0.12,
+                'rs1317082': 0.10,
+                'rs1801133': 0.19,
+                'rs1042522': 0.0,
+            }
+
+    @staticmethod
+    def load_genome_data(file_path: str) -> Dict[str, str]:
+        """Load genotype file into a dictionary."""
+        data: Dict[str, str] = {}
+        with open(file_path, 'r') as f:
+            for line in f:
+                if not line.strip() or line.startswith('#'):
+                    continue
+                parts = line.split()
+                if len(parts) >= 2:
+                    data[parts[0]] = parts[1].strip()
+        return data
+
+    def analyze_telomere_length(self, genome: Dict[str, str]) -> Dict[str, float]:
+        score = 0.0
+        found = 0
+        for snp, weight in self.telomere_markers.items():
+            if snp in genome:
+                score += _effect(genome[snp], 'A') * weight
+                found += 1
+        risk_level = 'Low'
+        if score < 0.4:
+            risk_level = 'High'
+        elif score < 0.7:
+            risk_level = 'Moderate'
+        return {
+            'markers_found': found,
+            'total_markers': len(self.telomere_markers),
+            'telomere_score': round(score, 2),
+            'risk_level': risk_level,
+        }
+
+    def calculate_polygenic_risk_score(self, genome: Dict[str, str]) -> Dict[str, float]:
+        score = 0.0
+        for snp, weight in self.polygenic_markers.items():
+            if snp in genome:
+                score += _effect(genome[snp], 'A' if snp != 'rs1042522' else 'C') * weight
+        normalized = score / self.total_markers
+        risk = 'Low'
+        if normalized < 0.4:
+            risk = 'High'
+        elif normalized < 0.7:
+            risk = 'Moderate'
+        return {
+            'markers_used': len(self.polygenic_markers),
+            'polygenic_score': normalized,
+            'overall_aging_risk': risk,
+            'aging_rate_probability': 1 - normalized,
+        }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ Modules include:
 
 **Disease** Risk: Major disease SNPs, polygenic risk scores, clear summaries.
 
-**Longevity**: Aging and protective markers, risk scores, recommendations.
+**Longevity**: Aging and protective markers, risk scores, recommendations. Two
+  scripts are provided in the ``Longevity`` folder:
+  ``Longevity.py`` for a quick summary and ``Comprehensive_Longevity.py`` for a
+  full probability-based analysis.
 
 **Fitness**: Athletic trait probabilities and insights.
 

--- a/run_all_analyses.py
+++ b/run_all_analyses.py
@@ -32,6 +32,8 @@ if __name__ == "__main__":
     run_analysis("Disease Testing/Disease.py")
     run_analysis("Disease Testing/Comprehensive_Disease.py")
     run_analysis("Ethnicity/Ethnicity.py")
+    run_analysis("Longevity/Longevity.py")
+    run_analysis("Longevity/Comprehensive_Longevity.py")
     
     print(f"\n{'='*60}")
     print("ANALYSIS COMPLETE")


### PR DESCRIPTION
## Summary
- add quick Longevity and full Comprehensive_Longevity analyzers
- include Longevity reports in run_all_analyses
- provide wrapper calculate_probability for tests
- implement LongevityAgingAnalyzer for test suite
- document new Longevity folder

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aaabc3794832aa170eff6ad23958e